### PR TITLE
Removing duplicated parameters

### DIFF
--- a/lib/mister_pasha_api/operations/create_booking.rb
+++ b/lib/mister_pasha_api/operations/create_booking.rb
@@ -33,8 +33,6 @@ module MisterPashaApi
           cmd_num_colis: "",
           cmd_poids: "",
           cmd_transporteur: "",
-          dest_addr_3: "",
-          dest_addr_4: "",
         }
       end
 

--- a/lib/mister_pasha_api/version.rb
+++ b/lib/mister_pasha_api/version.rb
@@ -1,3 +1,3 @@
 module MisterPashaApi
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end


### PR DESCRIPTION
Accidentally copied  `dest_addr_3` and `dest_addr_4` to the bottom of the list - removing those two parameters so they don't override original values. 