### PR TITLE
Refactoring TimeSlot class to deal better with last time slot

### DIFF
--- a/lib/mister_pasha_api/time_slot.rb
+++ b/lib/mister_pasha_api/time_slot.rb
@@ -24,18 +24,44 @@ module MisterPashaApi
 
     def local_start_time
       DateTime.parse(delivery_date).in_time_zone(PARIS_TIME_ZONE).change(
-        hour: slot[0..1], min: slot[3..4], sec: 0
+        hour: start_hour, min: start_minute, sec: 0
       )
     end
 
     def local_end_time
-      DateTime.parse(delivery_date).in_time_zone(PARIS_TIME_ZONE).change(
-        hour: slot[6..7], min: slot[9..10], sec: 0
+      DateTime.parse(delivery_date_for_end_time).in_time_zone(PARIS_TIME_ZONE).change(
+        hour: end_hour, min: end_minute, sec: 0
       )
     end
 
     def reference
       slot[0..10]
+    end
+
+    private
+
+    def delivery_date_for_end_time
+      start_hour.to_i < end_hour.to_i ? delivery_date : next_delivery_date
+    end
+
+    def next_delivery_date
+      Date.parse(delivery_date).tomorrow.to_s
+    end
+
+    def start_hour
+      slot[0..1]
+    end
+
+    def end_hour
+      slot[6..7]
+    end
+
+    def start_minute
+      slot[3..4]
+    end
+
+    def end_minute
+      slot[9..10]
     end
   end
 end

--- a/spec/time_slot_spec.rb
+++ b/spec/time_slot_spec.rb
@@ -12,6 +12,16 @@ describe MisterPashaApi::TimeSlot do
         "2019-06-03 18:00:00 +0200"
       )
     end
+
+    context "with last time slot" do
+      let(:slot) { "23h00-00h00-1" }
+
+      it "returns correct time slot starting time" do
+        expect(subject.local_start_time.to_s).to eq(
+          "2019-06-03 23:00:00 +0200"
+        )
+      end
+    end
   end
 
   describe "#local_end_time" do
@@ -19,6 +29,16 @@ describe MisterPashaApi::TimeSlot do
       expect(subject.local_end_time.to_s).to eq(
         "2019-06-03 19:00:00 +0200"
       )
+    end
+
+    context "with last time slot" do
+      let(:slot) { "23h00-00h00-1" }
+
+      it "returns correct time slot ending time" do
+        expect(subject.local_end_time.to_s).to eq(
+          "2019-06-04 00:00:00 +0200"
+        )
+      end
     end
   end
 


### PR DESCRIPTION
Fixing a small bug with last time slot. 

Problem:  the last time slot is between `23:00` and `00:00`. We are using delivery date to build `DateTime` object for end time - with `00:00` - delivery date is for the previous date. 